### PR TITLE
Match section names with square brackets

### DIFF
--- a/lib/Syntax/Kamelon/Indexer.pm
+++ b/lib/Syntax/Kamelon/Indexer.pm
@@ -227,13 +227,15 @@ sub LoadIndex {
 	unless ($noindex) { $file = $self->XMLFolder . '/' . $self->IndexFile }
 	if (-e $file) {
 		if (open(OFILE, "<", $file)) {
+			local our $re;
+			$re = qr{\[ ( (?: (?> [^[\]]+ ) | (??{ $re }) )* ) \]}x;
 			my %index = ();
 			my $section;
 			my %inf = ();
 			while (<OFILE>) {
 				my $line = $_;
 				chomp $line;
-				if ($line =~ /^\[([^\]]+)\]/) { #new section
+				if ($line =~ $re) { #new section
 					if (defined $section) { $index{$section} = { %inf } }
 					$section = $1;
 					%inf = ();


### PR DESCRIPTION
While writing [Statocles::Plugin::Highlight::Kamelon](https://metacpan.org/pod/Statocles::Plugin::Highlight::Kamelon), I realized that the [Indexer](https://github.com/haje61/Kamelon/blob/f5b315937be7a3fdfdee548c0a6a27aefb4254eb/lib/Syntax/Kamelon/Indexer.pm#L224) cuts sections names like `[KDev-PG[-Qt] Grammar]` at the first closing square bracket. The following command outputs `KDev-PG[-Qt`:

    perl -MSyntax::Kamelon -E 'say grep { /KDev/ } Syntax::Kamelon->new->AvailableSyntaxes'

This pull request replaces the regular expression in `LoadIndex()` with an expression from [perlre](https://perldoc.perl.org/perlre#(??%7B-code-%7D)) that handles nested brackets. It's unlikey that anybody will highlight KDev-PG[-Qt] grammers, but the fix is simple and could be included in a future release.